### PR TITLE
Workaround for "Minus sign spans multiple characters" when trying to write rtl date format to parcel

### DIFF
--- a/calcdialog/src/main/java/com/maltaisn/calcdialog/CalcSettings.java
+++ b/calcdialog/src/main/java/com/maltaisn/calcdialog/CalcSettings.java
@@ -20,6 +20,7 @@ import android.os.Bundle;
 import android.os.Parcel;
 import android.os.Parcelable;
 
+import java.lang.UnsupportedOperationException;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.text.NumberFormat;
@@ -330,7 +331,11 @@ public class CalcSettings implements Parcelable {
         if (maxValue != null) bundle.putSerializable("maxValue", maxValue);
         bundle.putBoolean("isOrderOfOperationsApplied", isOrderOfOperationsApplied);
 
-        out.writeBundle(bundle);
+        try{
+            out.writeBundle(bundle);
+        } catch (UnsupportedOperationException uoe){
+            // Workaround for issue https://issuetracker.google.com/issues/37043137
+        }
     }
 
     @Override


### PR DESCRIPTION
When the writeToParcel method is called on a device (mainly Android 5.0.x devices) with rtl languages the UnsupportedOperationException exception is throw.

This issue is related to an identified issue in Android (See https://issuetracker.google.com/issues/37043137)