### PR TITLE
Fix some NPE and upgrade dependencies

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,7 +22,7 @@ android {
 dependencies {
     testImplementation 'junit:junit:4.12'
 
-    implementation 'androidx.appcompat:appcompat:1.0.2'
+    implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
 
     implementation project(':calcdialog')

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath 'com.android.tools.build:gradle:3.5.1'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
 

--- a/calcdialog/build.gradle
+++ b/calcdialog/build.gradle
@@ -52,7 +52,7 @@ tasks.withType(Javadoc).all { enabled = false }
 dependencies {
     testImplementation 'junit:junit:4.12'
 
-    implementation 'androidx.appcompat:appcompat:1.0.2'
+    implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
 }
 

--- a/calcdialog/src/main/java/com/maltaisn/calcdialog/CalcDialog.java
+++ b/calcdialog/src/main/java/com/maltaisn/calcdialog/CalcDialog.java
@@ -292,7 +292,9 @@ public class CalcDialog extends AppCompatDialogFragment {
     @Override
     public void onSaveInstanceState(@NonNull Bundle state) {
         super.onSaveInstanceState(state);
-        presenter.writeStateToBundle(state);
+        if (presenter != null) {
+            presenter.writeStateToBundle(state);
+        }
         state.putParcelable("settings", settings);
     }
 

--- a/calcdialog/src/main/java/com/maltaisn/calcdialog/CalcDialog.java
+++ b/calcdialog/src/main/java/com/maltaisn/calcdialog/CalcDialog.java
@@ -21,6 +21,7 @@ import android.annotation.SuppressLint;
 import android.app.Dialog;
 import android.content.Context;
 import android.content.DialogInterface;
+import android.content.res.Resources;
 import android.content.res.TypedArray;
 import android.graphics.Rect;
 import android.os.Bundle;
@@ -254,7 +255,7 @@ public class CalcDialog extends AppCompatDialogFragment {
                 // Get maximum dialog dimensions
                 Rect fgPadding = new Rect();
                 dialog.getWindow().getDecorView().getBackground().getPadding(fgPadding);
-                DisplayMetrics metrics = context.getResources().getDisplayMetrics();
+                DisplayMetrics metrics = Resources.getSystem().getDisplayMetrics();
                 int height = metrics.heightPixels - fgPadding.top - fgPadding.bottom;
                 int width = metrics.widthPixels - fgPadding.top - fgPadding.bottom;
 

--- a/calcdialog/src/main/java/com/maltaisn/calcdialog/CalcPresenter.java
+++ b/calcdialog/src/main/java/com/maltaisn/calcdialog/CalcPresenter.java
@@ -490,15 +490,15 @@ class CalcPresenter {
                 // Append the decimal separator at the end of the number.
                 DecimalFormat fmt = (DecimalFormat) nbFormat;
                 char sep = fmt.getDecimalFormatSymbols().getDecimalSeparator();
-                if (currentValue.compareTo(BigDecimal.ZERO) >= 0) {
+                if (value.compareTo(BigDecimal.ZERO) >= 0) {
                     String suffixBefore = fmt.getPositiveSuffix();
                     fmt.setPositiveSuffix(sep + suffixBefore);
-                    text = nbFormat.format(currentValue);
+                    text = nbFormat.format(value);
                     fmt.setPositiveSuffix(suffixBefore);
                 } else {
                     String suffixBefore = fmt.getNegativeSuffix();
                     fmt.setNegativeSuffix(sep + suffixBefore);
-                    text = nbFormat.format(currentValue);
+                    text = nbFormat.format(value);
                     fmt.setNegativeSuffix(suffixBefore);
                 }
             } else {

--- a/calcdialog/src/main/java/com/maltaisn/calcdialog/CalcPresenter.java
+++ b/calcdialog/src/main/java/com/maltaisn/calcdialog/CalcPresenter.java
@@ -17,6 +17,7 @@
 package com.maltaisn.calcdialog;
 
 import android.os.Bundle;
+import android.os.Parcelable;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -133,7 +134,10 @@ class CalcPresenter {
     private void readStateFromBundle(Bundle bundle) {
         //noinspection ConstantConditions
         if (bundle.containsKey("expression")) {
-            expression = bundle.getParcelable("expression");
+            Parcelable parcelable = bundle.getParcelable("expression");
+            if (parcelable != null){
+                this.expression = (Expression) parcelable;
+            }
         }
         if (bundle.containsKey("currentValue")) {
             currentValue = (BigDecimal) bundle.getSerializable("currentValue");

--- a/calcdialog/src/main/java/com/maltaisn/calcdialog/CalcPresenter.java
+++ b/calcdialog/src/main/java/com/maltaisn/calcdialog/CalcPresenter.java
@@ -113,7 +113,9 @@ class CalcPresenter {
     }
 
     void writeStateToBundle(Bundle bundle) {
-        bundle.putParcelable("expression", expression);
+        if (expression != null) {
+            bundle.putParcelable("expression", expression);
+        }
         if (currentValue != null) {
             bundle.putSerializable("currentValue", currentValue);
         }
@@ -130,7 +132,9 @@ class CalcPresenter {
 
     private void readStateFromBundle(Bundle bundle) {
         //noinspection ConstantConditions
-        expression = bundle.getParcelable("expression");
+        if (bundle.containsKey("expression")) {
+            expression = bundle.getParcelable("expression");
+        }
         if (bundle.containsKey("currentValue")) {
             currentValue = (BigDecimal) bundle.getSerializable("currentValue");
         }

--- a/calcdialog/src/main/java/com/maltaisn/calcdialog/CalcSettings.java
+++ b/calcdialog/src/main/java/com/maltaisn/calcdialog/CalcSettings.java
@@ -78,6 +78,32 @@ public class CalcSettings implements Parcelable {
         return requestCode;
     }
 
+    /**
+     * Set the number format to use for formatting the currently displayed value and the
+     * values in the expression (if shown). This can be used to set a prefix and a suffix,
+     * changing the grouping settings, the minimum and maximum integer and fraction digits,
+     * the decimal separator, the rounding mode, and probably more.
+     * By default, the locale's default decimal format is used.
+     * @param format A number format.
+     * @return The settings
+     * @see NumberFormat
+     */
+    public CalcSettings setNumberFormat(@NonNull NumberFormat format) {
+        if (format.getRoundingMode() == RoundingMode.UNNECESSARY) {
+            throw new IllegalArgumentException("Cannot use RoundingMode.UNNECESSARY as a rounding mode.");
+        }
+
+        this.nbFormat = format;
+
+        // The max int setting on number format is used to set the maximum int digits that can be entered.
+        // However, it is possible that the user evaluates expressions resulting in bigger numbers.
+        // If not changed, this would show those values as "0,000" instead of "10,000" for example.
+        maxIntDigits = nbFormat.getMaximumIntegerDigits();
+        nbFormat.setMaximumIntegerDigits(Integer.MAX_VALUE);
+
+        return this;
+    }
+
     @NonNull
     public NumberFormat getNumberFormat() {
         return nbFormat;
@@ -268,6 +294,10 @@ public class CalcSettings implements Parcelable {
         requestCode = bundle.getInt("requestCode");
 
         //noinspection ConstantConditions
+        if (bundle.containsKey("nbFormat")){
+            nbFormat = (NumberFormat) bundle.getSerializable("nbFormat");
+        }
+        //noinspection ConstantConditions
         numpadLayout = (CalcNumpadLayout) bundle.getSerializable("numpadLayout");
         isExpressionShown = bundle.getBoolean("isExpressionShown");
         isZeroShownWhenNoValue = bundle.getBoolean("isZeroShownWhenNoValue");
@@ -289,6 +319,9 @@ public class CalcSettings implements Parcelable {
         Bundle bundle = new Bundle();
 
         bundle.putInt("requestCode", requestCode);
+        if (nbFormat != null){
+            bundle.putSerializable("nbFormat", nbFormat);
+        }
         bundle.putSerializable("numpadLayout", numpadLayout);
         bundle.putBoolean("isExpressionShown", isExpressionShown);
         bundle.putBoolean("isZeroShownWhenNoValue", isZeroShownWhenNoValue);

--- a/calcdialog/src/main/java/com/maltaisn/calcdialog/CalcSettings.java
+++ b/calcdialog/src/main/java/com/maltaisn/calcdialog/CalcSettings.java
@@ -21,6 +21,7 @@ import android.os.Parcel;
 import android.os.Parcelable;
 
 import java.lang.UnsupportedOperationException;
+import java.lang.NullPointerException;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.text.NumberFormat;
@@ -295,7 +296,12 @@ public class CalcSettings implements Parcelable {
 
         //noinspection ConstantConditions
         if (bundle.containsKey("nbFormat")){
+            try {
             nbFormat = (NumberFormat) bundle.getSerializable("nbFormat");
+            } catch (NullPointerException npe){
+                // Catch NPE exception on some Android 9 devices
+                // see https://stackoverflow.com/q/53541154/8941877
+            }
         }
         //noinspection ConstantConditions
         numpadLayout = (CalcNumpadLayout) bundle.getSerializable("numpadLayout");

--- a/calcdialog/src/main/java/com/maltaisn/calcdialog/CalcSettings.java
+++ b/calcdialog/src/main/java/com/maltaisn/calcdialog/CalcSettings.java
@@ -290,34 +290,35 @@ public class CalcSettings implements Parcelable {
     ////////// PARCELABLE //////////
     private CalcSettings(Parcel in) {
         Bundle bundle = in.readBundle(getClass().getClassLoader());
-        assert bundle != null;
+        if (bundle != null) {
 
-        requestCode = bundle.getInt("requestCode");
+            requestCode = bundle.getInt("requestCode");
 
-        //noinspection ConstantConditions
-        if (bundle.containsKey("nbFormat")){
-            try {
-            nbFormat = (NumberFormat) bundle.getSerializable("nbFormat");
-            } catch (NullPointerException npe){
-                // Catch NPE exception on some Android 9 devices
-                // see https://stackoverflow.com/q/53541154/8941877
+            //noinspection ConstantConditions
+            if (bundle.containsKey("nbFormat")) {
+                try {
+                    nbFormat = (NumberFormat) bundle.getSerializable("nbFormat");
+                } catch (NullPointerException npe) {
+                    // Catch NPE exception on some Android 9 devices
+                    // see https://stackoverflow.com/q/53541154/8941877
+                }
             }
-        }
-        //noinspection ConstantConditions
-        numpadLayout = (CalcNumpadLayout) bundle.getSerializable("numpadLayout");
-        isExpressionShown = bundle.getBoolean("isExpressionShown");
-        isZeroShownWhenNoValue = bundle.getBoolean("isZeroShownWhenNoValue");
-        isAnswerBtnShown = bundle.getBoolean("isAnswerBtnShown");
-        isSignBtnShown = bundle.getBoolean("isSignBtnShown");
-        shouldEvaluateOnOperation = bundle.getBoolean("shouldEvaluateOnOperation");
+            //noinspection ConstantConditions
+            numpadLayout = (CalcNumpadLayout) bundle.getSerializable("numpadLayout");
+            isExpressionShown = bundle.getBoolean("isExpressionShown");
+            isZeroShownWhenNoValue = bundle.getBoolean("isZeroShownWhenNoValue");
+            isAnswerBtnShown = bundle.getBoolean("isAnswerBtnShown");
+            isSignBtnShown = bundle.getBoolean("isSignBtnShown");
+            shouldEvaluateOnOperation = bundle.getBoolean("shouldEvaluateOnOperation");
 
-        if (bundle.containsKey("initialValue"))
-            initialValue = (BigDecimal) bundle.getSerializable("initialValue");
-        if (bundle.containsKey("minValue"))
-            minValue = (BigDecimal) bundle.getSerializable("minValue");
-        if (bundle.containsKey("maxValue"))
-            maxValue = (BigDecimal) bundle.getSerializable("maxValue");
-        isOrderOfOperationsApplied = bundle.getBoolean("isOrderOfOperationsApplied");
+            if (bundle.containsKey("initialValue"))
+                initialValue = (BigDecimal) bundle.getSerializable("initialValue");
+            if (bundle.containsKey("minValue"))
+                minValue = (BigDecimal) bundle.getSerializable("minValue");
+            if (bundle.containsKey("maxValue"))
+                maxValue = (BigDecimal) bundle.getSerializable("maxValue");
+            isOrderOfOperationsApplied = bundle.getBoolean("isOrderOfOperationsApplied");
+        }
     }
 
     @Override

--- a/calcdialog/src/main/java/com/maltaisn/calcdialog/CalcSettings.java
+++ b/calcdialog/src/main/java/com/maltaisn/calcdialog/CalcSettings.java
@@ -294,7 +294,9 @@ public class CalcSettings implements Parcelable {
         requestCode = bundle.getInt("requestCode");
 
         //noinspection ConstantConditions
-        nbFormat = (NumberFormat) bundle.getSerializable("nbFormat");
+        if (bundle.containsKey("nbFormat")){
+            nbFormat = (NumberFormat) bundle.getSerializable("nbFormat");
+        }
         //noinspection ConstantConditions
         numpadLayout = (CalcNumpadLayout) bundle.getSerializable("numpadLayout");
         isExpressionShown = bundle.getBoolean("isExpressionShown");
@@ -317,9 +319,10 @@ public class CalcSettings implements Parcelable {
         Bundle bundle = new Bundle();
 
         bundle.putInt("requestCode", requestCode);
-
+        if (nbFormat != null){
+            bundle.putSerializable("nbFormat", nbFormat);
+        }
         bundle.putSerializable("numpadLayout", numpadLayout);
-        bundle.putSerializable("nbFormat", nbFormat);
         bundle.putBoolean("isExpressionShown", isExpressionShown);
         bundle.putBoolean("isZeroShownWhenNoValue", isZeroShownWhenNoValue);
         bundle.putBoolean("isAnswerBtnShown", isAnswerBtnShown);

--- a/calcdialog/src/main/java/com/maltaisn/calcdialog/CalcSettings.java
+++ b/calcdialog/src/main/java/com/maltaisn/calcdialog/CalcSettings.java
@@ -78,32 +78,6 @@ public class CalcSettings implements Parcelable {
         return requestCode;
     }
 
-    /**
-     * Set the number format to use for formatting the currently displayed value and the
-     * values in the expression (if shown). This can be used to set a prefix and a suffix,
-     * changing the grouping settings, the minimum and maximum integer and fraction digits,
-     * the decimal separator, the rounding mode, and probably more.
-     * By default, the locale's default decimal format is used.
-     * @param format A number format.
-     * @return The settings
-     * @see NumberFormat
-     */
-    public CalcSettings setNumberFormat(@NonNull NumberFormat format) {
-        if (format.getRoundingMode() == RoundingMode.UNNECESSARY) {
-            throw new IllegalArgumentException("Cannot use RoundingMode.UNNECESSARY as a rounding mode.");
-        }
-
-        this.nbFormat = format;
-
-        // The max int setting on number format is used to set the maximum int digits that can be entered.
-        // However, it is possible that the user evaluates expressions resulting in bigger numbers.
-        // If not changed, this would show those values as "0,000" instead of "10,000" for example.
-        maxIntDigits = nbFormat.getMaximumIntegerDigits();
-        nbFormat.setMaximumIntegerDigits(Integer.MAX_VALUE);
-
-        return this;
-    }
-
     @NonNull
     public NumberFormat getNumberFormat() {
         return nbFormat;
@@ -294,10 +268,6 @@ public class CalcSettings implements Parcelable {
         requestCode = bundle.getInt("requestCode");
 
         //noinspection ConstantConditions
-        if (bundle.containsKey("nbFormat")){
-            nbFormat = (NumberFormat) bundle.getSerializable("nbFormat");
-        }
-        //noinspection ConstantConditions
         numpadLayout = (CalcNumpadLayout) bundle.getSerializable("numpadLayout");
         isExpressionShown = bundle.getBoolean("isExpressionShown");
         isZeroShownWhenNoValue = bundle.getBoolean("isZeroShownWhenNoValue");
@@ -319,9 +289,6 @@ public class CalcSettings implements Parcelable {
         Bundle bundle = new Bundle();
 
         bundle.putInt("requestCode", requestCode);
-        if (nbFormat != null){
-            bundle.putSerializable("nbFormat", nbFormat);
-        }
         bundle.putSerializable("numpadLayout", numpadLayout);
         bundle.putBoolean("isExpressionShown", isExpressionShown);
         bundle.putBoolean("isZeroShownWhenNoValue", isZeroShownWhenNoValue);

--- a/calcdialog/src/main/java/com/maltaisn/calcdialog/Expression.java
+++ b/calcdialog/src/main/java/com/maltaisn/calcdialog/Expression.java
@@ -128,7 +128,7 @@ class Expression implements Parcelable {
     ////////// PARCELABLE //////////
     private Expression(Parcel in) {
         in.readList(numbers, BigDecimal.class.getClassLoader());
-        in.readList(numbers, Operator.class.getClassLoader());
+        in.readList(operators, Operator.class.getClassLoader());
     }
 
     @Override


### PR DESCRIPTION
This PR fix some issues found on some devices:

- `currentValue` used instead of `value` and produce NPE
- `assert bundle != null;` is never reach in a release app, so we need to check is the bundle is not null.
- Expression from parcel read list of operators in the wrong variable
- Add conditional check due to issue on some devices

Bump appcompat dependencies to version 1.1.0
