### PR TITLE
Fix form of the verb in polish translations

### DIFF
--- a/lib/src/main/res/values-pl/strings.xml
+++ b/lib/src/main/res/values-pl/strings.xml
@@ -1,6 +1,6 @@
 <resources>
 
-    <string name="calc_dialog_clear">Wymazać</string>
+    <string name="calc_dialog_clear">Wymaż</string>
     <string name="calc_dialog_cancel">Anuluj</string>
     <string name="calc_dialog_ok">OK</string>
 
@@ -13,6 +13,6 @@
         <item>Wynik musi być ujemny</item>
     </string-array>
 
-    <string name="calc_dialog_erase">Wymazać</string>
+    <string name="calc_dialog_erase">Wymaż</string>
 
 </resources>


### PR DESCRIPTION
"Wymazać" was infinitive form.