### PR TITLE
Fixed maxIntDigits not accounting for a minus (-)

### DIFF
--- a/lib/src/main/java/com/maltaisn/calcdialog/CalcPresenter.java
+++ b/lib/src/main/java/com/maltaisn/calcdialog/CalcPresenter.java
@@ -201,7 +201,8 @@ class CalcPresenter {
 
         // Check if max digits has been exceeded
         int pointPos = valueStr.indexOf('.');
-        boolean maxIntReached = (pointPos == -1 && valueStr.length() >= settings.maxIntDigits);
+        int intDigits = (pointPos == -1 ? valueStr.length() : pointPos) - (!valueStr.isEmpty() && valueStr.charAt(0) == '-' ? 1 : 0);
+        boolean maxIntReached = (intDigits >= settings.maxIntDigits);
         boolean maxFracReached = (pointPos != -1 && valueStr.length() - pointPos - 1 >= nbFormat.getMaximumFractionDigits());
         if (maxIntReached || maxFracReached) {
             // Can't add a new digit, it's already at the maximum.


### PR DESCRIPTION
[device-2023-02-25-185420.webm](https://user-images.githubusercontent.com/27736965/221363801-4f5f8b47-f4de-4635-b602-06bc8e14b9fa.webm)

As seen in the short recording above, if the number you are typing is positive, you can type upto `maxIntDigits`, and if you then change the sign, you'll have a minus (`-`) and `maxIntDigits` number of digits, as you'd expect. However, if you remove one digit and try to type it again, you'll not be able to do so, as the current implementation assumes that all characters before the decimal separator are digits, which may include the minus (`-`) character.

My solution is to simply substract 1 to the number of characters before the decimal separator if the string is not empty and the first character is a minus (`-`). I put it into a separate `intDigits` variable for readabilty, though that can be changed if you prefere otherwise.